### PR TITLE
Fix compile error on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,13 @@ use {
         fmt::Debug,
         fs::{self, DirEntry, Permissions},
         io::{self, Write as _},
-        os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
         sync::{PoisonError, RwLock},
     },
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 /// Defines size thresholds for rotating log files in various units.
 ///


### PR DESCRIPTION
This PR fixes the following error on Windows:

```
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> C:\Users\ContainerAdministrator\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\logroller-0.1.7\src\lib.rs:55:13
   |
55 |         os::unix::fs::PermissionsExt,
   |             ^^^^ could not find `unix` in `os`
```