### PR TITLE
Only stat() directory entries which match the log file pattern.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,12 +572,12 @@ impl LogRollerMeta {
 
         let mut all_log_files = Vec::new();
         for file in files.flatten() {
-            let metadata = file.metadata().map_err(LogRollerError::FileIOError)?;
-            if !metadata.is_file() {
-                continue;
-            }
             if let Some(file_name) = file.file_name().to_str() {
                 if file_pattern.is_match(file_name) {
+                    let metadata = file.metadata().map_err(LogRollerError::FileIOError)?;
+                    if !metadata.is_file() {
+                        continue;
+                    }
                     all_log_files.push(file);
                 }
             }


### PR DESCRIPTION
When checking the files to rotate we first do a directory listing, then use stat() to match only files, and then find all those whose name matches a given pattern.

If the stat() call fails either because of permission issues, or because an entry has been deleted, we return an error.

This commit changes the ordering so that we only call stat() on entries which match the pattern. This reduces the number of stat() calls we make and reduces the risk that we get an error if an unrelated file in the log directory is deleted.

Without this change if any file in the log directory gets deleted between the directory listing and stat() we get an IOError.